### PR TITLE
fix: remove broken category validator that rejected valid enum values

### DIFF
--- a/api/validators/inventory_validation.py
+++ b/api/validators/inventory_validation.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field as PydanticField, field_validator
+from pydantic import BaseModel, Field as PydanticField
 
 from models.entity.inventory_entity import InventoryCategory
 
@@ -13,14 +13,6 @@ class AddInventoryPayload(BaseModel):
     category: InventoryCategory
     price: float = 0.0
     notes: Optional[str] = None
-
-    @field_validator("category", mode="before")
-    def check_category(cls, v):
-        if not isinstance(v, InventoryCategory):
-            raise ValueError(
-                f"invalid category value: must be part of {list(InventoryCategory.__members__.values())}"
-            )
-        return v
 
 
 class AddInventoryResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Removes the `@field_validator("category", mode="before")` from `AddInventoryPayload` in `api/validators/inventory_validation.py`
- The validator checked `isinstance(v, InventoryCategory)` before Pydantic coerced the incoming string — so valid values like `"PRODUCE"` were always rejected with a 422, making it impossible to add inventory from the frontend
- Pydantic handles enum coercion natively; the custom validator was redundant and broken

## Test plan
- [ ] Log in as a grocer and add an item to inventory from the Products page
- [ ] Verify all category values (GROCERY, PRODUCE, MEAT, DAIRY, BAKERY, OTHER) are accepted
- [ ] Verify invalid category values still return a 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)