### PR TITLE
test: update store profile test — website is now optional

### DIFF
--- a/tests/integration/test_platform.py
+++ b/tests/integration/test_platform.py
@@ -103,14 +103,13 @@ class TestAuth:
         )
         assert r.status_code == 200
 
-    def test_set_store_profile_requires_website(self, store_token):
+    def test_set_store_profile_without_website(self, store_token):
         r = client.post(
             "/user/set-profile",
             json={"name": "No Website Store", "email": "nosite@groceror.test"},
             headers=_headers(store_token),
         )
-        assert r.status_code == 400
-        assert "Website is required" in r.json()["detail"]
+        assert r.status_code == 200
 
     def test_refresh_token(self, user_token):
         r = client.get("/user/refresh-token", headers=_headers(user_token))


### PR DESCRIPTION
## Summary
- Updates `test_set_store_profile_requires_website` → `test_set_store_profile_without_website`
- Asserts `200` instead of `400` now that the website-required guard was removed in PR #45
- All other tests pass; the 11 remaining failures (9 cart + 2 store ordering) are pre-existing on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)