### PR TITLE
Replace YAML config with .env / python-dotenv

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,24 +3,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Dict
 
-import yaml
+from dotenv import load_dotenv
 
-# Load .config.yml if present (local dev). On Render (and other cloud envs)
-# the file won't exist — config comes from environment variables instead.
-_cfg_path = Path(".config.yml")
-_file: dict = yaml.safe_load(_cfg_path.read_text()) if _cfg_path.exists() else {}
+# Load .env if present (local dev). In cloud envs the vars are injected directly.
+load_dotenv(Path(__file__).parent / ".env")
 
 
-def _cfg(*keys: str, env: str = None, default: str = "") -> str:
-    """Return config value: env var > .config.yml > default."""
-    if env and os.environ.get(env):
-        return os.environ[env]
-    val: Any = _file
-    for k in keys:
-        val = (val or {}).get(k)
-        if val is None:
-            return default
-    return val or default
+def _env(key: str, default: str = "") -> str:
+    return os.environ.get(key, default)
 
 
 @dataclass
@@ -62,14 +52,13 @@ class LogConfig:
 
 @dataclass
 class DBConfig(object):
-    """Database configuration — prefers DATABASE_URL env var (Render/Supabase),
-    falls back to individual fields from .config.yml for local dev."""
+    """Database configuration — prefers DATABASE_URL, falls back to individual fields."""
 
-    DB_URL: ClassVar[str] = os.environ.get("DATABASE_URL") or (
+    DB_URL: ClassVar[str] = _env("DATABASE_URL") or (
         "postgresql://"
-        f"{_cfg('groceror', 'db', 'DB_USER')}:{_cfg('groceror', 'db', 'DB_PASSWORD')}"
-        f"@{_cfg('groceror', 'db', 'DB_HOST')}:{_cfg('groceror', 'db', 'DB_PORT')}"
-        f"/{_cfg('groceror', 'db', 'DB_NAME')}"
+        f"{_env('DB_USER')}:{_env('DB_PASSWORD')}"
+        f"@{_env('DB_HOST')}:{_env('DB_PORT', '5432')}"
+        f"/{_env('DB_NAME', 'postgres')}"
     )
 
 
@@ -77,45 +66,25 @@ class DBConfig(object):
 class JWTConfig(object):
     """JWT related configuration"""
 
-    JWT_ALGORITHM: ClassVar[str] = _cfg(
-        "groceror", "jwt", "JWT_ALGORITHM", env="JWT_ALGORITHM", default="HS256"
-    )
-    JWT_SECRET_KEY: ClassVar[str] = _cfg(
-        "groceror", "jwt", "JWT_SECRET_KEY", env="JWT_SECRET_KEY"
-    )
+    JWT_ALGORITHM: ClassVar[str] = _env("JWT_ALGORITHM", "HS256")
+    JWT_SECRET_KEY: ClassVar[str] = _env("JWT_SECRET_KEY")
 
 
 @dataclass
 class TwilioConfig(object):
     """Twilio SMS configuration"""
 
-    ACCOUNT_SID: ClassVar[str] = _cfg(
-        "groceror", "twilio", "account_sid", env="TWILIO_ACCOUNT_SID"
-    )
-    AUTH_TOKEN: ClassVar[str] = _cfg(
-        "groceror", "twilio", "auth_token", env="TWILIO_AUTH_TOKEN"
-    )
-    FROM_NUMBER: ClassVar[str] = _cfg(
-        "groceror", "twilio", "from_number", env="TWILIO_FROM_NUMBER"
-    )
+    ACCOUNT_SID: ClassVar[str] = _env("TWILIO_ACCOUNT_SID")
+    AUTH_TOKEN: ClassVar[str] = _env("TWILIO_AUTH_TOKEN")
+    FROM_NUMBER: ClassVar[str] = _env("TWILIO_FROM_NUMBER")
 
 
 @dataclass
 class RabbitMQConfig(object):
     """RabbitMQ connection configuration"""
 
-    HOST: ClassVar[str] = _cfg(
-        "groceror", "rabbitmq", "host", env="RABBITMQ_HOST", default="localhost"
-    )
-    PORT: ClassVar[int] = int(
-        _cfg("groceror", "rabbitmq", "port", env="RABBITMQ_PORT", default="5672")
-    )
-    USER: ClassVar[str] = _cfg(
-        "groceror", "rabbitmq", "user", env="RABBITMQ_USER", default="guest"
-    )
-    PASSWORD: ClassVar[str] = _cfg(
-        "groceror", "rabbitmq", "password", env="RABBITMQ_PASSWORD", default="guest"
-    )
-    VHOST: ClassVar[str] = _cfg(
-        "groceror", "rabbitmq", "virtual_host", env="RABBITMQ_VHOST", default="/"
-    )
+    HOST: ClassVar[str] = _env("RABBITMQ_HOST", "localhost")
+    PORT: ClassVar[int] = int(_env("RABBITMQ_PORT", "5672"))
+    USER: ClassVar[str] = _env("RABBITMQ_USER", "guest")
+    PASSWORD: ClassVar[str] = _env("RABBITMQ_PASSWORD", "guest")
+    VHOST: ClassVar[str] = _env("RABBITMQ_VIRTUAL_HOST", "/")


### PR DESCRIPTION
## Summary
- Replaces `.config.yml` (pyyaml) with a flat `.env` file loaded via `python-dotenv`
- Removes the nested YAML key lookup helper `_cfg()` — all config classes now read directly from `os.environ` via a simple `_env()` wrapper
- `.env` is gitignored; `.config.yml.bak` preserved locally as a reference

## Test plan
- [ ] Run the app locally and confirm DB, JWT, Twilio, and RabbitMQ configs load correctly from `.env`
- [ ] Verify cloud deploys (Render/AWS) still work — env vars are injected directly and `load_dotenv` is a no-op when `.env` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)