### PR TITLE
Fix unit tests: mock JWT secret and Twilio in conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,8 @@ import config as _config
 
 _SQLITE_URL = "sqlite:////tmp/test_groceror.db"
 _config.DBConfig.DB_URL = _SQLITE_URL  # type: ignore[assignment]
+_config.JWTConfig.JWT_SECRET_KEY = "test-secret-key-padded-to-32-bytes!!"  # type: ignore[assignment]
+_config.TwilioConfig.ACCOUNT_SID = ""  # skip real SMS — send_sms falls back to stdout
 
 from sqlmodel import create_engine as _ce, SQLModel, Session as _Session  # noqa: E402
 import models.db as _db  # noqa: E402


### PR DESCRIPTION
## Summary
- Patch `JWTConfig.JWT_SECRET_KEY` in `conftest.py` with a test value so tests don't fail when `.env` is absent (e.g. CI)
- Blank `TwilioConfig.ACCOUNT_SID` so `send_sms` uses its stdout fallback instead of making real Twilio API calls with fake test phone numbers

## Root cause
`send_sms` already guards against empty credentials — no production code needed to change. The fix follows the same pattern as the existing `DBConfig.DB_URL` override in conftest.

## Test plan
- [x] `test_login` passes
- [x] `test_set_profile_publishes_profile_updated` passes
- [x] `test_change_password_publishes_password_changed` passes
- [x] Full unit suite: 89 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)